### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/narichvirus/f61df377-bcdb-4c67-9a6e-43a28ec60213/9af59ce5-311a-4ed5-bbb6-0e009a9d4b40/_apis/work/boardbadge/14436b1b-af87-482e-ae74-95a096f8e2dd)](https://dev.azure.com/narichvirus/f61df377-bcdb-4c67-9a6e-43a28ec60213/_boards/board/t/9af59ce5-311a-4ed5-bbb6-0e009a9d4b40/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/narichvirus/f61df377-bcdb-4c67-9a6e-43a28ec60213/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.